### PR TITLE
Update stats-rank library.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@types/jest": "29.5.0",
     "@types/lodash": "^4.14.191",
+    "@stdlib/types": "^0.4.1",
     "@jest/globals": "29.5.0",
     "esbuild": "0.17.5",
     "jest": "29.5.0",
@@ -36,7 +37,7 @@
     "dist/**/*"
   ],
   "dependencies": {
-    "@stdlib/stats-ranks": "^0.1.0",
+    "@stdlib/stats-ranks": "^0.2.2",
     "lodash": "^4.17.21",
     "simple-statistics": "^7.8.3"
   }


### PR DESCRIPTION
This fixes an installation issue on *nix, and probably MacOS:

https://github.com/stdlib-js/stdlib/issues/2122

```
# npm install jandas
[...]
npm error gyp: binding.gyp not found (cwd: ***/node_modules/@stdlib/math-base-assert-is-integer) while trying to load binding.gyp
```

And a build issue:

```
Jandas# npm install
[...]
> tsc

node_modules/@stdlib/stats-ranks/docs/types/index.d.ts:21:23 - error TS2688: Cannot find type definition file for '@stdlib/types'.
```